### PR TITLE
Use shell for bootstrap, not puppet.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -114,14 +114,9 @@ Vagrant.configure('2') do |config|
   # #               Managed by Puppet.\n"
   # # }
   #
-
+  #
   # A quick bootstrap to get Puppet installed.
-  config.vm.provision :puppet do |puppet|
-    puppet.manifests_path = "manifests"
-    puppet.manifest_file  = "bootstrap.pp"
-    puppet.module_path = "modules"
-    #puppet.options = "--verbose --debug"
-  end
+  config.vm.provision "shell", path: "scripts/bootstrap.sh"
 
   # And now the meat.
   config.vm.provision :puppet do |puppet|

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Only run once.
+if [ ! -f /var/.parrot-bootstrapped ]; then
+  # Run some bootstrapping stuff here.
+
+  # Need to update the apt cache.
+  apt-get update
+
+  # Need to make sure we have the latest version of puppet.
+  DEBIAN_FRONTEND=noninteractive apt-get -q -y install puppet
+
+  # Ensure that we only run once.
+  touch /var/.parrot-bootstrapped
+fi


### PR DESCRIPTION
We can do a faster and more reliable bootstrap by using a shell script instead of puppet.
