### PR TITLE
Adding optional support for standard naming of web root sub directories.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ def parse_config(
   require 'yaml'
   config = {
     'sites' => "sites",
+    'webroot_subdir' => "",
     'databases' => "databases",
     'memory' => '2048',
     'with_gui' => false,
@@ -122,7 +123,8 @@ Vagrant.configure('2') do |config|
     # Add a custom fact so we can reliably hit the host IP from the guest.
     puppet.facter = {
       "vagrant_guest_ip" => custom_config['ip'],
-      "parrot_php_version" => custom_config['php_version']
+      "parrot_php_version" => custom_config['php_version'],
+      "apache_vhost_webroot_subdir" => custom_config['webroot_subdir']
     }
   end
 end

--- a/modules/http_stack/templates/apache/vhost.erb
+++ b/modules/http_stack/templates/apache/vhost.erb
@@ -2,12 +2,12 @@
 	ServerAdmin webmaster@localhost
         ServerName <%= @name %>
 
-	DocumentRoot /vagrant_sites/<%= @name %>
+	DocumentRoot /vagrant_sites/<%= @name %><%= @apache_vhost_webroot_subdir %>
 	<Directory />
 		Options FollowSymLinks
 		AllowOverride None
 	</Directory>
-	<Directory /vagrant_sites/<%= @name %>/>
+	<Directory /vagrant_sites/<%= @name %><%= @apache_vhost_webroot_subdir %>/>
 		Options Indexes FollowSymLinks MultiViews
 		AllowOverride All
 		<IfModule mod_authz_core.c>
@@ -36,12 +36,12 @@
 		ServerAdmin webmaster@localhost
 	        ServerName <%= @name %>
 
-		DocumentRoot /vagrant_sites/<%= @name %>
+		DocumentRoot /vagrant_sites/<%= @name %><%= @apache_vhost_webroot_subdir %>
 		<Directory />
 			Options FollowSymLinks
 			AllowOverride None
 		</Directory>
-		<Directory /vagrant_sites/<%= @name %>/>
+		<Directory /vagrant_sites/<%= @name %><%= @apache_vhost_webroot_subdir %>/>
 			Options Indexes FollowSymLinks MultiViews
 			AllowOverride All
       <IfModule mod_authz_core.c>


### PR DESCRIPTION
In our work flow, we have a git repository with a web folder in the root of the git repo. This web folder is what we want to specify as the web root. So when we create a folder under the parrot 'sites' folder such as 'newsite', we actually want the web root to point at 'newsite/web'.

Adding this optional configuration to the config.yml file in the same way as has been done for php version and box name seems like a sensible approach.

I've never sent a pull request before, so not sure if this is the right way to do so, let me know if not, it is about time I figured it out!

Hoping to start using the main parrot for all our local development environments and thus add to it's growth and improvement.

Many thanks.

Finn.
