### PR TITLE
Configurable forwarding and cpus

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ def parse_config(
     'webroot_subdir' => "",
     'databases' => "databases",
     'memory' => '2048',
+    'cpus' => '2',
     'with_gui' => false,
     'ip' => "192.168.50.4",
     'php_version' => '5.3',
@@ -77,6 +78,9 @@ Vagrant.configure('2') do |config|
     else
       override.vm.box_url = "http://files.vagrantup.com/precise64.box"
     end
+
+    # Specify number of cpus/cores to use
+    box.customize ["modifyvm", :id, "--cpus", custom_config['cpus']]
 
     box.customize ['modifyvm', :id, '--memory', custom_config['memory']]
     box.name = custom_config['box_name']


### PR DESCRIPTION
A take on making whether to forward ports as well as the number of cpus configurable.

Two things that should be considered:
1. The forwarding-configuration might be a bit to fine-grained, in my case I just wanted everything switched off, it could be enough just to have one configuration for whether to do the forwarding at all
2. I have only tested the cpu-configuration on virtualbox, no idea whether the same configuration works on vmware
