### PR TITLE
Adding an optional Drush installation inside the Parrot vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,8 @@ def parse_config(
     'varnish_enabled' => false,
     'local_user_uid' => Process.uid,
     'local_user_gid' => Process.gid,
+    'drush_installed' => false,
+    'drush_branch' => '6.x',
     'forward_solr' => true,
     'forward_mysql' => true,
     'forward_varnish' => true,
@@ -158,6 +160,8 @@ Vagrant.configure('2') do |config|
       "parrot_varnish_enabled" => custom_config['varnish_enabled'],
       "vagrant_host_user_uid" => custom_config['local_user_uid'],
       "vagrant_host_user_gid" => custom_config['local_user_gid'],
+      "parrot_drush_installed" => custom_config['drush_installed'],
+      "parrot_drush_branch" => custom_config['drush_branch'],
     }
   end
 end

--- a/manifests/parrot.pp
+++ b/manifests/parrot.pp
@@ -27,6 +27,15 @@ node default {
     autoupdate => true,
   }
 
+  # Optionally install drush
+  case $parrot_drush_installed {
+    'true', true: {
+      class {'drush':
+        drush_branch => $parrot_drush_branch,
+      }
+    }
+  }
+
 
 
 }

--- a/modules/drush/manifests/init.pp
+++ b/modules/drush/manifests/init.pp
@@ -28,7 +28,7 @@ class drush (
         # Run once to download console table etc.
         exec { "drush_first_run":
           command => "/opt/drush/drush",
-          require => Exec['clone_drush'],
+          require => [Exec['clone_drush'],Package["php5-readline"]],
         }
 
       }

--- a/modules/drush/manifests/init.pp
+++ b/modules/drush/manifests/init.pp
@@ -1,0 +1,66 @@
+class drush (
+  $drush_branch = '6.x',
+  $git_repo = 'https://github.com/drush-ops/drush.git'
+) {
+
+    include parrot_php::composer
+
+    # Check that git is installed.
+    if ! defined(Package['git']) {
+      package { 'git':
+        ensure => present,
+        before => Exec['clone_drush'],
+      }
+    }
+
+    case $drush_branch {
+      # 6.x branch, fine for most Drupal 7 uses.
+      '6.x': {
+        exec { 'clone_drush':
+          path => "/bin:/usr/bin",
+          cwd => "/opt",
+          command => "git clone -b $drush_branch $git_repo",
+          creates => "/opt/drush",
+          require => [Package["git-core"]],
+        }
+
+        # Complete Drush install
+        # Run once to download console table etc.
+        exec { "drush_first_run":
+          command => "/opt/drush/drush",
+          require => Exec['clone_drush'],
+        }
+
+      }
+      # 7.x branch, required for Drupal 8
+      '7.x', default: {
+        exec { 'clone_drush':
+          path => "/bin:/usr/bin",
+          cwd => "/opt",
+          command => "git clone -b $drush_branch $git_repo",
+          creates => "/opt/drush",
+          require => [Class['parrot_php::composer'], Package["git-core"]],
+          notify => Exec['composer_drush_install'],
+        }
+
+        # Complete Drush install by running "composer install" in the Drush directory.
+        exec { 'composer_drush_install':
+          command => '/usr/local/bin/composer install',
+          environment => [ "COMPOSER_HOME=/opt/drush" ],
+          cwd => '/opt/drush',
+          refreshonly => true,
+          require => Exec['clone_drush'],
+        }
+
+      }
+    }
+
+  # Symlink Drush
+  file { 'symlink_drush':
+    ensure => link,
+    path => '/usr/bin/drush',
+    target => '/opt/drush/drush',
+    require => Exec['clone_drush'],
+  }
+
+}

--- a/modules/drush/manifests/init.pp
+++ b/modules/drush/manifests/init.pp
@@ -49,7 +49,7 @@ class drush (
           environment => [ "COMPOSER_HOME=/opt/drush" ],
           cwd => '/opt/drush',
           refreshonly => true,
-          require => Exec['clone_drush'],
+          require => [Exec['clone_drush'],Package["php5-readline"]],
         }
 
       }

--- a/modules/drush/manifests/init.pp
+++ b/modules/drush/manifests/init.pp
@@ -28,7 +28,7 @@ class drush (
         # Run once to download console table etc.
         exec { "drush_first_run":
           command => "/opt/drush/drush",
-          require => [Exec['clone_drush'],Package["php5-readline"]],
+          require => [Exec['clone_drush']],
         }
 
       }
@@ -49,7 +49,7 @@ class drush (
           environment => [ "COMPOSER_HOME=/opt/drush" ],
           cwd => '/opt/drush',
           refreshonly => true,
-          require => [Exec['clone_drush'],Package["php5-readline"]],
+          require => [Exec['clone_drush']],
         }
 
       }

--- a/modules/parrot_php/manifests/composer.pp
+++ b/modules/parrot_php/manifests/composer.pp
@@ -1,0 +1,44 @@
+class parrot_php::composer {
+
+  if ! defined(Package['curl']) {
+    package { 'curl':
+      ensure => present,
+      before => Exec['composer_install'],
+    }
+  }
+
+  case $lsbdistcodename {
+    'trusty': {
+      # This may be needed on 14.04, but not 12.04?
+      file_line { 'suhosin.executor.include.whitelist = phar':
+        path => '/etc/php5/cli/conf.d/suhosin.ini',
+        line => 'suhosin.executor.include.whitelist = phar',
+      }
+
+      exec { 'composer_install':
+        command => 'curl -sS https://getcomposer.org/installer | php && sudo mv composer.phar /usr/local/bin/composer',
+        creates => '/usr/local/bin/composer',
+        require => [
+          File_line['suhosin.executor.include.whitelist = phar'],
+          Class['parrot_php'],
+        ],
+      }
+
+    }
+    'precise': {
+
+      exec { 'composer_install':
+        command => 'curl -sS https://getcomposer.org/installer | php && sudo mv composer.phar /usr/local/bin/composer',
+        creates => '/usr/local/bin/composer',
+        path => "/bin:/usr/bin",
+        cwd => "/tmp",
+        require => [
+          Class['parrot_php'],
+        ],
+      }
+
+    }
+
+  }
+
+}

--- a/modules/parrot_php/manifests/init.pp
+++ b/modules/parrot_php/manifests/init.pp
@@ -17,6 +17,7 @@ class parrot_php (
    'php5-xmlrpc',
    'php5-xdebug',
    'php5-fpm',
+   'php5-readline',
   ]
 
   #Install PHP

--- a/modules/parrot_php/manifests/init.pp
+++ b/modules/parrot_php/manifests/init.pp
@@ -2,6 +2,7 @@ class parrot_php (
   $fpm_user_uid  = $vagrant_host_user_uid,
   $fpm_user_gid  = $vagrant_host_user_gid,
 )
+
 {
 
   $php_packages = [
@@ -17,13 +18,20 @@ class parrot_php (
    'php5-xmlrpc',
    'php5-xdebug',
    'php5-fpm',
-   'php5-readline',
   ]
 
   #Install PHP
   package { $php_packages:
     ensure => 'latest',
     require => Class["parrot_repos"],
+  }
+
+  # Readline is included with PHP 5.3 but not later versions.
+  if $parrot_php_version > 5.3 {
+    package { 'php5-readline':
+      ensure => 'latest',
+      require => Class["parrot_repos"],
+    }
   }
 
   # We don't use xhprof from the ubuntu package any more.


### PR DESCRIPTION
Hi Steven,

hope all is well with you and fammily!

We often need Drush inside the Parrot based vagrant box, so I've added support for additional configuration options via config.yml. 
For example 
adding this to config.yml

```
drush_installed: true 
```

should be enough to install drush (defaulting to 6.x branch).
Doing the following will install the latest 7.x branch, for Drupal 8:

```
drush_installed: true 
drush_branch: '7.x' 
```

I've tested it on a fresh vagrant up from scratch and it works for me on both 6.x and 7.x branches.
I'm sure there are probably more efficient ways to install composer, and to clone repos, but this works for now.
Any chance you could merge it into Parrot?

Cheers,

Finn
