### PR TITLE
Increase xdebug max nesting level.

### DIFF
--- a/parrot-config/php/parrot-base.ini
+++ b/parrot-config/php/parrot-base.ini
@@ -51,7 +51,7 @@ apc.user_ttl=7200
 ; Enable remote debugging
 xdebug.remote_enable=1
 ; Stop potential inifinte loops, while allowing enough depth for Drupal
-xdebug.max_nesting_level=200
+xdebug.max_nesting_level=256
 xdebug.remote_handler=dbgp
 
 ; Set the remote address to the default address of our host machine, magic.


### PR DESCRIPTION
See https://www.drupal.org/node/2393531 and http://bugs.xdebug.org/bug_view_page.php?bug_id=00001100. Apparently setting this value to 256 was considered adequate on Xdebug 2.3, and is even a requirement for Drupal 8.