### PR TITLE
 [trusty] $key_source is deprecated #99 

### DIFF
--- a/modules/parrot_repos/manifests/init.pp
+++ b/modules/parrot_repos/manifests/init.pp
@@ -2,10 +2,12 @@ class parrot_repos {
 
   # Add a repo for Varnish.
   apt::source { 'varnish':
-  	  location   => 'http://repo.varnish-cache.org/ubuntu/',
-  	  repos      => 'varnish-3.0',
-  	  release    => 'trusty',
-  	  key        => "C4DEFFEB",
-      key_source => "http://repo.varnish-cache.org/debian/GPG-key.txt",
+      location   => 'http://repo.varnish-cache.org/ubuntu/',
+      repos      => 'varnish-3.0',
+      release    => 'trusty',
+      key        => {
+        "id"     => "C4DEFFEB",
+        "source" => "http://repo.varnish-cache.org/debian/GPG-key.txt",
+      },
   }
 }


### PR DESCRIPTION
This removes one of the varnish that comes when running vagrant provision