### PR TITLE
Feature/composer drush

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ def parse_config(
     'cpus' => '1',
     'with_gui' => false,
     'ip' => "192.168.50.4",
-    'php_version' => '5.3',
+    'php_version' => '5.5',
     'mysql_version' => '5.5',
     'box_name' => 'Parrot-Trusty',
     'varnish_enabled' => false,
@@ -30,6 +30,7 @@ def parse_config(
     'apache_port' => 8080,
     'https_port' => 1443,
     'dovecot_port' => 1143,
+    'drush_version' => 'drush/drush',
   }
   if File.exists?(config_file)
     overrides = YAML.load_file(config_file)
@@ -173,6 +174,7 @@ Vagrant.configure('2') do |config|
     puppet.module_path = ["forge-modules", "modules"]
     # Add a custom fact so we can reliably hit the host IP from the guest.
     puppet.facter = {
+      "parrot_drush_version" => custom_config['drush_version'],
       "vagrant_guest_ip" => custom_config['ip'],
       "parrot_php_version" => custom_config['php_version'],
       "parrot_mysql_version" => custom_config['mysql_version'],

--- a/manifests/parrot.pp
+++ b/manifests/parrot.pp
@@ -17,6 +17,7 @@ node default {
       class { 'http_stack::without_varnish': }
     }
   }
+  class { parrot_drush: }
   class { mailcollect: }
 
   package { 'vim': }

--- a/modules/parrot_drush/manifests/init.pp
+++ b/modules/parrot_drush/manifests/init.pp
@@ -12,15 +12,15 @@ class parrot_drush {
     command     => "/usr/local/bin/composer global require $parrot_drush_version",
     user        => 'vagrant',
     require     => Class['php::composer'],
-    environment => 'COMPOSER_HOME=/composer',
+    environment => 'COMPOSER_HOME=/home/vagrant',
   }
 
   # Make drush executional.
   # TODO A better solution would be to modify the .bashrc file instead of
-  # making a symlink for the drush bin.
+  # making a symlink for the drush file.
   file { '/usr/local/bin/drush':
      ensure => 'link',
-     target => '/composer/vendor/drush/drush/drush.php',
+     target => '/home/vagrant/.composer/vendor/drush/drush/drush.php',
   }
 
 }

--- a/modules/parrot_drush/manifests/init.pp
+++ b/modules/parrot_drush/manifests/init.pp
@@ -1,0 +1,26 @@
+class parrot_drush {
+
+  # Make sure we have a place to put our composer items.
+  file {'/composer':
+    owner => 'vagrant',
+    group => 'vagrant',
+    ensure => 'directory',
+  }
+
+  # Install/Update drush
+  exec {'Install/Update drush' :
+    command     => "/usr/local/bin/composer global require $parrot_drush_version",
+    user        => 'vagrant',
+    require     => Class['php::composer'],
+    environment => 'COMPOSER_HOME=/composer',
+  }
+
+  # Make drush executional.
+  # TODO A better solution would be to modify the .bashrc file instead of
+  # making a symlink for the drush bin.
+  file { '/usr/local/bin/drush':
+     ensure => 'link',
+     target => '/composer/vendor/drush/drush/drush.php',
+  }
+
+}

--- a/modules/parrot_php/manifests/init.pp
+++ b/modules/parrot_php/manifests/init.pp
@@ -185,4 +185,8 @@ class parrot_php (
     comment => 'Added automatically by Parrot',
     ensure => 'present',
   }
+
+  # Add composer with autoupdate.
+  class { ['php::composer', 'php::composer::auto_update']:}
+
 }


### PR DESCRIPTION
This installs composer and latest drush stable version. It's possible to configure which drush version you want to install with composer.

I also updated the PHP version in the Vagrantfile, we don't really use this, but seems odd to have the default value be 5.3, so updated it to be 5.5.

This fixes #103 