### PR TITLE
Adding option for gulp installed with nodejs 4.x.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,7 @@ def parse_config(
     'https_port' => 1443,
     'dovecot_port' => 1143,
     'drush_version' => 'drush/drush',
+    'gulp_enabled' => false,
   }
   if File.exists?(config_file)
     overrides = YAML.load_file(config_file)
@@ -174,6 +175,7 @@ Vagrant.configure('2') do |config|
       "parrot_mysql_version" => custom_config['mysql_version'],
       "apache_vhost_webroot_subdir" => custom_config['webroot_subdir'],
       "parrot_varnish_enabled" => custom_config['varnish_enabled'],
+      "parrot_gulp_enabled" => custom_config['gulp_enabled'],
       "vagrant_host_user_uid" => custom_config['local_user_uid'],
       "vagrant_host_user_gid" => custom_config['local_user_gid'],
     }

--- a/manifests/parrot.pp
+++ b/manifests/parrot.pp
@@ -46,6 +46,27 @@ node default {
     require => Anchor["parrot:repos"],
   }
 
-
+  # Install gulp with nodejs if required.
+  case $parrot_gulp_enabled {
+    'true', true: {
+      # Add sources for nodejs binaries and install nodejs package.
+      # See: https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions
+      exec { 'nodejs_sources' :
+        command => 'curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -',
+        path => '/usr/bin',
+        creates => '/etc/apt/sources.list.d/nodesource.list',
+      }
+      package { 'nodejs':
+        ensure => installed,
+        require => Exec['nodejs_sources'],
+      }
+      exec { 'install_gulp' :
+        command => 'npm install --global gulp-cli',
+        path => '/usr/bin',
+        creates => '/usr/bin/gulp',
+        require => Package['nodejs'],
+      }
+    }
+  }
 
 }


### PR DESCRIPTION
Hi Steven,
any chance of merging this into your master to allow us to run with our optional nodejs based gulp sass compilation inside the VM?
I tried an install from the forge module https://forge.puppet.com/puppet/nodejs but this ran into issues which appeared to require a more recent version of Puppet, so went with the suggestions on https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions
Cheers,
Finn