### PR TITLE
Adding php-mysql package 

### DIFF
--- a/modules/parrot_php/manifests/init.pp
+++ b/modules/parrot_php/manifests/init.pp
@@ -39,6 +39,7 @@ class parrot_php (
     # 'php7.0-xhprof',
 
     'php-uploadprogress',
+    'php-mysql',
 
   ]
 


### PR DESCRIPTION
which seems to be required by drush command line to prevent `Error: Undefined class constant MYSQL_ATTR_SSL_CA`

On a fresh install a couple of times recently, the first time I try to run drush I get the above error. A quick google and apt-get install php-mysql seems to fix it.

Not 100% clear why! 