### PR TITLE
Double the timeout on DB imports

### DIFF
--- a/modules/parrot_mysql/manifests/database_import.pp
+++ b/modules/parrot_mysql/manifests/database_import.pp
@@ -17,6 +17,7 @@ define parrot_mysql::database_import {
       refreshonly => true,
       subscribe => Exec["create-db-$name"],
       command => "/usr/bin/mysql -uroot -proot $db_name < /vagrant_databases/$name",
+      timeout => 600,
     }
   }
   elsif $name =~ /\.sql.gz$/ {
@@ -24,6 +25,7 @@ define parrot_mysql::database_import {
       refreshonly => true,
       subscribe => Exec["create-db-$name"],
       command => "/bin/zcat /vagrant_databases/$name | /usr/bin/mysql -uroot -proot $db_name",
+      timeout => 600,
     }
   }
   else{


### PR DESCRIPTION
Database imports quite often take too long for timeouts. I know they carry on importing anyway, but the fact that a `parrot provision` completes often confuses users who then expect the database to be completely imported, if they (mistakenly) ignore the error output on its completion.

As a fairly naive attempt to improve this, can we double the timeout for the database imports? (I believe 600 is double the default value (300), if I understand https://puppet.com/docs/puppet/5.3/types/exec.html#exec-attribute-timeout correctly)

Alternatively, we could disable the timeout completely (but is some kind of timeout a good thing?), or could it even be set dynamically, e.g. according to the size of the dump file being imported?